### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BernhardAngerer/simple-speedtest-client/security/code-scanning/6](https://github.com/BernhardAngerer/simple-speedtest-client/security/code-scanning/6)

To fix the issue, add a minimal `permissions` block at the workflow or job level. The best and least-privilege default is to explicitly specify `permissions: contents: read` at the root of the workflow, so all jobs inherit this setting unless they need to override it. This matches the needs of a typical Maven build job, which only needs to check out source and does not need to write to repository contents, issues, etc.

**Change details:**
- Add the following under the `name:` line (after line 9), before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or further changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
